### PR TITLE
Make Meilisearch calls async

### DIFF
--- a/ePaperless_be/requirements.txt
+++ b/ePaperless_be/requirements.txt
@@ -37,7 +37,7 @@ launchpadlib==1.10.16
 lazr.restfulclient==0.14.4
 lazr.uri==1.0.6
 lxml==5.2.1
-meilisearch==0.31.0
+meilisearch-python-sdk==2.8.0
 more-itertools==8.10.0
 netifaces==0.11.0
 numpy==1.21.5

--- a/ePaperless_task_schedule/main.py
+++ b/ePaperless_task_schedule/main.py
@@ -40,7 +40,7 @@ async def periodic_upload_check():
             ocr = extract_text_from_document(file_path)
             #print('Text extracted: \n', ocr)
 
-            milisearch_result = post_values(new_file_name, sin, ocr, "N/A", tags, metadata, "N/A")
+            milisearch_result = await post_values(new_file_name, sin, ocr, "N/A", tags, metadata, "N/A")
             print("Milisearch result: ", milisearch_result)
 
             result_file = await upload_to_s3(file_path, new_file_name)

--- a/ePaperless_task_schedule/util/mili_search.py
+++ b/ePaperless_task_schedule/util/mili_search.py
@@ -1,26 +1,27 @@
-import meilisearch
+import meilisearch_python_sdk
 import os
 import requests
 import uuid
 import time
 import json
 
-# client = meilisearch.Client('http://localhost:7700', 'masterkey')
-client = meilisearch.Client('http://localhost:7700')
+# client = meilisearch_python_sdk.AsyncClient('http://localhost:7700', 'masterkey')
+client = meilisearch_python_sdk.AsyncClient("http://localhost:7700")
 
-def post_values(
-        file_name, 
-        sin="N/A", 
-        extracted_text="N/A", 
-        content_type="N/A", 
-        tags="N/A", 
-        meta="N/A", 
-        description="N/A"
-    ):
 
+async def post_values(
+    file_name,
+    sin="N/A",
+    extracted_text="N/A",
+    content_type="N/A",
+    tags="N/A",
+    meta="N/A",
+    description="N/A",
+):
     # An index is where the documents are stored.
-    index = client.index('epaperless')
-    data=[{
+    index = client.index("epaperless")
+    data = [
+        {
             "id": str(uuid.uuid4()),
             "doc_name": file_name,
             "sin": sin,
@@ -30,10 +31,9 @@ def post_values(
             "creator": "",
             "tags": tags,
             "meta": meta,
-            "description": description
-    }]
+            "description": description,
+        }
+    ]
 
     # If the index 'movies' does not exist, Meilisearch creates it when you first add the documents.
-    index.add_documents(data) # => { "uid": 0 }
-
-
+    await index.add_documents(data)  # => { "uid": 0 }


### PR DESCRIPTION
This PR makes the calls to Meilisearch async to prevent blocking the event loop.